### PR TITLE
Add Hermes Tweet skill metadata

### DIFF
--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -50,7 +50,7 @@ Examples:
   # Remove a skill
   npx aiskill remove ui-ux-pro-max --agent claude --scope project
 
-For more information, visit: https://github.com/inferera/skills-repo
+For more information, visit: https://github.com/AIhubmix/skills-repo
 `);
 }
 

--- a/docs/sync-analysis-report.md
+++ b/docs/sync-analysis-report.md
@@ -84,7 +84,7 @@ git commit: fix: improve sync workflow - better caching and conflict handling
 
 1. **访问 Actions 设置页面**:
    ```
-   https://github.com/inferera/skills-repo/settings/actions
+   https://github.com/AIhubmix/skills-repo/settings/actions
    ```
 
 2. **检查权限配置**:
@@ -96,7 +96,7 @@ git commit: fix: improve sync workflow - better caching and conflict handling
      - ✅ "Allow GitHub Actions to create and approve pull requests"
 
 3. **启用 Workflows**:
-   访问: `https://github.com/inferera/skills-repo/actions`
+   访问: `https://github.com/AIhubmix/skills-repo/actions`
 
    如果看到 "Workflows disabled" 或类似提示:
    - 点击 "I understand my workflows, go ahead and enable them" 或 "Enable workflows"
@@ -125,7 +125,7 @@ actions:
 
 #### 方法 A: 通过 GitHub UI (推荐)
 
-1. 访问: `https://github.com/inferera/skills-repo/actions/workflows/sync.yml`
+1. 访问: `https://github.com/AIhubmix/skills-repo/actions/workflows/sync.yml`
 2. 点击右上角 "Run workflow" 下拉按钮
 3. 选择 branch: `main`
 4. (可选) 设置 `force_fetch: true` 强制更新所有技能
@@ -171,7 +171,7 @@ git pull
 git log --oneline --author="github-actions" -5
 
 # 或访问 GitHub 查看 Actions 执行历史
-https://github.com/inferera/skills-repo/actions/workflows/sync.yml
+https://github.com/AIhubmix/skills-repo/actions/workflows/sync.yml
 ```
 
 ### 步骤 4: 推送本次修复
@@ -224,7 +224,7 @@ git push origin main
 gh run list --workflow=sync.yml --limit 10
 
 # 或访问
-https://github.com/inferera/skills-repo/actions/workflows/sync.yml
+https://github.com/AIhubmix/skills-repo/actions/workflows/sync.yml
 ```
 
 ---
@@ -274,7 +274,7 @@ for (let i = 0; i < skills.length; i += 5) {
 **A**: GitHub Actions 的定时任务在 fork 仓库默认禁用，需要手动启用。
 
 ### Q: 如何确认定时任务已启用？
-**A**: 访问 `https://github.com/inferera/skills-repo/actions`，查看是否有 "Sync Skills" 的执行记录。
+**A**: 访问 `https://github.com/AIhubmix/skills-repo/actions`，查看是否有 "Sync Skills" 的执行记录。
 
 ### Q: 为什么本地有 .sync-result.json 但没有自动提交？
 **A**: .sync-result.json 是本地运行 `npm run sync:check` 生成的，不代表 GitHub Actions 有运行。
@@ -292,7 +292,7 @@ for (let i = 0; i < skills.length; i += 5) {
 如果遇到问题:
 
 1. **查看 Actions 日志**:
-   `https://github.com/inferera/skills-repo/actions`
+   `https://github.com/AIhubmix/skills-repo/actions`
 
 2. **检查本地同步**:
    ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,16 @@
 {
-  "name": "skills-registry",
+  "name": "aiskill",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "skills-registry",
+      "name": "aiskill",
+      "version": "1.0.0",
+      "license": "MIT",
+      "bin": {
+        "aiskill": "cli/index.mjs"
+      },
       "devDependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "keywords": ["skills", "ai", "agents", "claude", "codex", "cursor", "opencode", "antigravity", "cli"],
   "repository": {
     "type": "git",
-    "url": "https://github.com/inferera/skills-repo.git"
+    "url": "https://github.com/AIhubmix/skills-repo.git"
   },
   "author": "",
   "license": "MIT",

--- a/registry/categories.json
+++ b/registry/categories.json
@@ -1,6 +1,6 @@
 {
   "specVersion": 2,
-  "generatedAt": "2026-07-17T20:24:28.337Z",
+  "generatedAt": "2026-07-19T12:30:08.389Z",
   "categories": [
     {
       "id": "development",

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,6 +1,6 @@
 {
   "specVersion": 2,
-  "generatedAt": "2026-07-17T20:24:28.337Z",
+  "generatedAt": "2026-07-19T12:30:08.389Z",
   "skills": [
     {
       "specVersion": 2,
@@ -2456,6 +2456,59 @@
         },
         {
           "path": "scripts/inspect_pr_checks.py",
+          "kind": "file"
+        },
+        {
+          "path": "SKILL.md",
+          "kind": "file"
+        }
+      ]
+    },
+    {
+      "specVersion": 2,
+      "id": "hermes-tweet",
+      "title": "Hermes Tweet",
+      "description": "Use Xquik from Hermes Agent for X search, posting, replies, likes, retweets, follows, DMs, monitors, extraction jobs, draws, media, and trends. Not affiliated with X Corp.",
+      "category": "tools",
+      "license": "MIT",
+      "authors": [
+        {
+          "name": "Xquik",
+          "url": "https://github.com/Xquik-dev/hermes-tweet"
+        }
+      ],
+      "tags": [
+        "hermes-agent",
+        "xquik",
+        "twitter",
+        "x",
+        "social-media",
+        "automation"
+      ],
+      "agents": [
+        "hermes-agent",
+        "codex"
+      ],
+      "source": {
+        "repo": "https://github.com/Xquik-dev/hermes-tweet",
+        "path": "skills/hermes-tweet",
+        "ref": "master",
+        "syncedCommit": "52d28943b8c50d4e4df2c21d52a2286c148e1c0e"
+      },
+      "links": {
+        "homepage": "https://github.com/Xquik-dev/hermes-tweet",
+        "docs": "https://github.com/Xquik-dev/hermes-tweet#readme",
+        "repo": "https://github.com/Xquik-dev/hermes-tweet"
+      },
+      "repoPath": "skills/tools/hermes-tweet",
+      "summary": "## Overview",
+      "files": [
+        {
+          "path": "references/endpoint-contract.md",
+          "kind": "file"
+        },
+        {
+          "path": "skill-card.md",
           "kind": "file"
         },
         {

--- a/registry/search-index.json
+++ b/registry/search-index.json
@@ -1,6 +1,6 @@
 {
   "specVersion": 2,
-  "generatedAt": "2026-07-17T20:24:28.337Z",
+  "generatedAt": "2026-07-19T12:30:08.389Z",
   "docs": [
     {
       "id": "figma",
@@ -145,6 +145,24 @@
       "tags": [],
       "agents": [],
       "text": "Gh Pr Checks Plan Fix\nUse when a user asks to debug or fix failing GitHub PR checks that run in GitHub Actions; use `gh` to inspect checks and logs, summarize failure context, draft a fix plan, and implement only after explicit approval. Treat external providers (for example Buildkite) as out of scope and report only the details URL.\n## Overview"
+    },
+    {
+      "id": "hermes-tweet",
+      "category": "tools",
+      "title": "Hermes Tweet",
+      "tags": [
+        "hermes-agent",
+        "xquik",
+        "twitter",
+        "x",
+        "social-media",
+        "automation"
+      ],
+      "agents": [
+        "hermes-agent",
+        "codex"
+      ],
+      "text": "Hermes Tweet\nUse Xquik from Hermes Agent for X search, posting, replies, likes, retweets, follows, DMs, monitors, extraction jobs, draws, media, and trends. Not affiliated with X Corp.\nhermes-agent xquik twitter x social-media automation\n## Overview"
     },
     {
       "id": "pdf",

--- a/site/.env.example
+++ b/site/.env.example
@@ -2,8 +2,8 @@
 NEXT_PUBLIC_SITE_NAME=Skills Registry
 
 # Repository Configuration
-# Format: owner/repo (e.g., inferera/skills-repo)
-NEXT_PUBLIC_REPO_SLUG=inferera/skills-repo
+# Format: owner/repo (e.g., AIhubmix/skills-repo)
+NEXT_PUBLIC_REPO_SLUG=AIhubmix/skills-repo
 NEXT_PUBLIC_REPO_REF=main
 
 # Site URL (optional, for production)

--- a/skills/tools/hermes-tweet/.x_skill.yaml
+++ b/skills/tools/hermes-tweet/.x_skill.yaml
@@ -1,0 +1,28 @@
+specVersion: 2
+id: hermes-tweet
+title: Hermes Tweet
+description: Use Xquik from Hermes Agent for X search, posting, replies, likes, retweets, follows, DMs, monitors, extraction jobs, draws, media, and trends. Not affiliated with X Corp.
+category: tools
+license: MIT
+authors:
+  - name: Xquik
+    url: https://github.com/Xquik-dev/hermes-tweet
+tags:
+  - hermes-agent
+  - xquik
+  - twitter
+  - x
+  - social-media
+  - automation
+agents:
+  - hermes-agent
+  - codex
+source:
+  repo: https://github.com/Xquik-dev/hermes-tweet
+  path: skills/hermes-tweet
+  ref: master
+  syncedCommit: 52d28943b8c50d4e4df2c21d52a2286c148e1c0e
+links:
+  homepage: https://github.com/Xquik-dev/hermes-tweet
+  docs: https://github.com/Xquik-dev/hermes-tweet#readme
+  repo: https://github.com/Xquik-dev/hermes-tweet


### PR DESCRIPTION
## Summary

- Add Hermes Tweet as a tools-category skill.
- Sync its current public source state into registry outputs.
- Add the compact X Corp. independence disclosure to public metadata.
- Repair stale repository URLs in package metadata, CLI help, and workflow documentation.
- Reconcile the root lockfile with the published package metadata.

## Validation

- `npm run validate`
- `npm run sync:skills` with 22 of 22 skills synced
- `npm run build:registry:no-sync`
- `npm run check:registry`
- Full static site build with 315 pages generated
- CLI help and default registry URL assertions
- `git diff --check`

The remaining GitHub Actions and Vercel authorization gates require a repository team member. The registry and site validations pass locally.

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
